### PR TITLE
Update the runtime version from 24.08 to 25.08, and more

### DIFF
--- a/org.hlwd.sonofman.yml
+++ b/org.hlwd.sonofman.yml
@@ -1,20 +1,27 @@
 app-id: org.hlwd.sonofman
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: som
 finish-args:
   - --socket=x11
   - --share=ipc
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/doc
+  - /share/man
+  - '*.la'
+  - '*.a'
 modules:
-  - pypi-dependencies.json 
+  - pypi-dependencies.json
   - name: libxmu-dev
     buildsystem: autotools
     sources:
       - type: archive
         url: http://archive.ubuntu.com/ubuntu/pool/main/libx/libxmu/libxmu_1.1.3.orig.tar.gz
         sha256: 5bd9d4ed1ceaac9ea023d86bf1c1632cd3b172dce4a193a72a94e1d9df87a62e
-  - name: xclip 
+  - name: xclip
     buildsystem: autotools
     sources:
       - type: git
@@ -35,7 +42,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/hotlittlewhitedog/BibleMultiTheSonOfMan.git
-        tag: 'v3.6.1'
+        tag: v3.6.1
       - type: file
         path: org.hlwd.sonofman.metainfo.xml
       - type: file

--- a/pypi-dependencies.json
+++ b/pypi-dependencies.json
@@ -1,24 +1,35 @@
 {
-    "name": "python3-xerox",
+    "name": "pypi-dependencies",
     "buildsystem": "simple",
-    "build-commands": [
-        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"setuptools\" \"xerox\" \"wcwidth\" --no-build-isolation"
-    ],
-    "sources": [
+    "build-commands": [],
+    "modules": [
         {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/a8/f2/48a3fb98b128e77e0c1e15a80c71d397c1ac1a4ed6db00e3e7307f767f93/xerox-0.4.1.tar.gz",
-            "sha256": "1b598ed4ba017374f02e9cef983febdd19dba79a5301856fdba985c490b14325"
+            "name": "python3-xerox",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"xerox\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a8/f2/48a3fb98b128e77e0c1e15a80c71d397c1ac1a4ed6db00e3e7307f767f93/xerox-0.4.1.tar.gz",
+                    "sha256": "1b598ed4ba017374f02e9cef983febdd19dba79a5301856fdba985c490b14325"
+                }
+            ]
         },
         {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz",
-            "sha256": "72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/5e/11/487b18cc768e2ae25a919f230417983c8d5afa1b6ee0abd8b6db0b89fa1d/setuptools-72.1.0.tar.gz",
-            "sha256": "8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec"
+            "name": "python3-wcwidth",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"wcwidth\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl",
+                    "sha256": "5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
- Update the runtime version to 25.08
- Update Python dependencies
- Improve cleanup commands to reduce the Flatpak size